### PR TITLE
Add support for PHP 8.1

### DIFF
--- a/src/CachingGenerator.php
+++ b/src/CachingGenerator.php
@@ -4,6 +4,7 @@ namespace Lunkkun\CachingGenerator;
 
 use Generator;
 use OuterIterator;
+use ReturnTypeWillChange;
 
 class CachingGenerator implements OuterIterator
 {
@@ -18,6 +19,7 @@ class CachingGenerator implements OuterIterator
         $this->addCurrentToCache();
     }
 
+    #[ReturnTypeWillChange]
     public function current()
     {
         return current($this->cache);


### PR DESCRIPTION
[Migrating from PHP 8.0.x to PHP 8.1.x](https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.core.type-compatibility-internal)
> Most non-final internal methods now require overriding methods to declare a compatible return type, otherwise a deprecated notice is emitted during inheritance validation. In case the return type cannot be declared for an overriding method due to PHP cross-version compatibility concerns, a #[ReturnTypeWillChange] attribute can be added to silence the deprecation notice.

Another solution (but incompatible with PHP < 8.0) is to add the `mixed` return type to `CachingGenerator::current()`.

Also see: https://wiki.php.net/rfc/internal_method_return_types.